### PR TITLE
docs: Update the global documentation k8

### DIFF
--- a/Infrastructure-as-code/Kubernetes/mongodb-express-app/index.md
+++ b/Infrastructure-as-code/Kubernetes/mongodb-express-app/index.md
@@ -7,12 +7,13 @@ This demo application showcases a Kubernetes architecture that includes the foll
 - Pods
 - Services
 - Deployments
-- Ingress
+- ConfigMap
+- Secrets
 
 The application demonstrates how a user can hit an external IP address, which allows the external Kubernetes service to communicate with the Mongo Express pod, which in turn connects to the internal MongoDB service, ultimately communicating with the MongoDB pod where the database resides.
 
-Use the workspace-startup.sh script to remove related components
-Use the workspace-delete.sh script to remove related components
+Use the `workspace-startup.sh` script to create related components
+Use the `workspace-delete.sh` script to remove related components
 
 ## File Structure
 
@@ -44,3 +45,8 @@ This file contains the configuration for deploying the Mongo Express pod. Mongo 
 ### 4. MongoDB ConfigMap (`mongo-configmap.yaml`)
 
 This file defines the configuration map for MongoDB. It contains non-sensitive configuration data that the MongoDB pod needs to function correctly.
+
+## Troubleshooting
+
+- If you use minikube, don't forget to start your `minikube tunnel`.
+- For POC purpose the `ME_CONFIG_BASICAUTH` has been configured to `false`, this is not recommended on live environments.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains best practices and examples for DevOps, including Infra
 - **Infrastructure-as-code/**: Contains IaC examples using Terraform and Pulumi.
 - **Scripting/**: Contains operational scripts for various tasks.
 - **Pipelines/**: Contains CI/CD pipeline configurations for GitLab CI and GitHub Actions.
+- **Containerized application/**: Contains basic POC for containerized applications (dockers / Kubernetes).
 - **Docs/**: Contains documentation for each section.
 
 ## Getting Started


### PR DESCRIPTION
Updating the global documentation and the k8 for the mongo-express-app to be the default page on github